### PR TITLE
install repo in disabled state

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -5,6 +5,7 @@
     name: xcat-core
     description: xCAT core packages
     baseurl: "{{ xcat_repo_core_url }}"
+    enabled: no
     gpgcheck: yes
     gpgkey: "{{ xcat_repo_core_gpg_key_url }}"
     state: present
@@ -14,6 +15,7 @@
     name: xcat-dep
     description: xCAT dependency packages
     baseurl: "{{ xcat_repo_dep_url }}"
+    enabled: no
     gpgcheck: yes
     gpgkey: "{{ xcat_repo_dep_gpg_key_url }}"
     state: present


### PR DESCRIPTION
- working with enablerepo option when installing software via ansible
  with yum
- needed for ufz eve issue where xcat repo should be disabled by default